### PR TITLE
Update route permissions and sidebar access for Forest page

### DIFF
--- a/src/0_app/router/routes.tsx
+++ b/src/0_app/router/routes.tsx
@@ -464,7 +464,7 @@ export const ROUTES: RouteConfig[] = [
     path: ROUTES_PATH.FOREST,
     variant: "private",
     element: <Forest />,
-    allowedRoles: [ROLES.ADMIN, ROLES.FOREST],
+    allowedRoles: [ROLES.ADMIN, ROLES.FOREST, ROLES.OFFICE_USER, ROLES.PARTNER],
     allowedUsers: [2758, 2564, 59, 156, 14, 19, 200, 154, 208, 138],
     layout: Sidebar,
     label: "Проект Лес",

--- a/src/2_widgets/sidebar/ui/sidebar.tsx
+++ b/src/2_widgets/sidebar/ui/sidebar.tsx
@@ -133,6 +133,9 @@ const Sidebar = ({
               icon: TreePine,
               disabled:
                 session?.role !== ROLES.ADMIN &&
+                session?.role !== ROLES.FOREST &&
+                session?.role !== ROLES.OFFICE_USER &&
+                session?.role !== ROLES.PARTNER &&
                 ![2758, 2564, 2758, 2564, 59, 156, 14, 19, 200].includes(
                   session?.idUser ?? -1,
                 ),


### PR DESCRIPTION
- Expanded allowedRoles for the Forest route to include OFFICE_USER and PARTNER.
- Adjusted sidebar access logic to reflect the new role permissions for the Forest page.