### PR TITLE
Update route permissions and sidebar access for Unload and Forest pages

### DIFF
--- a/src/0_app/router/routes.tsx
+++ b/src/0_app/router/routes.tsx
@@ -423,7 +423,7 @@ export const ROUTES: RouteConfig[] = [
     path: ROUTES_PATH.UNLOAD,
     variant: "private",
     element: <Unload />,
-    allowedRoles: [ROLES.ADMIN],
+    allowedRoles: [ROLES.ADMIN, ROLES.ANALITIK],
     allowedUsers: [107, 200, 2816],
     layout: Sidebar,
     label: "Выгрузка",
@@ -464,8 +464,11 @@ export const ROUTES: RouteConfig[] = [
     path: ROUTES_PATH.FOREST,
     variant: "private",
     element: <Forest />,
-    allowedRoles: [ROLES.ADMIN, ROLES.FOREST, ROLES.OFFICE_USER, ROLES.PARTNER],
-    allowedUsers: [2758, 2564, 59, 156, 14, 19, 200, 154, 208, 138],
+    allowedRoles: [
+      ...Object.values(ROLES).filter(
+        (role) => role !== ROLES.MANAGER_STORE && role !== ROLES.FARMER,
+      ),
+    ],
     layout: Sidebar,
     label: "Проект Лес",
   },

--- a/src/2_widgets/sidebar/ui/sidebar.tsx
+++ b/src/2_widgets/sidebar/ui/sidebar.tsx
@@ -98,11 +98,7 @@ const Sidebar = ({
                 {
                   title: "Проект Лес",
                   url: ROUTES_PATH.FOREST,
-                  disabled:
-                    session?.role !== ROLES.ADMIN &&
-                    ![2758, 2564, 2758, 2564, 59, 156, 14, 19, 200].includes(
-                      session?.idUser ?? -1,
-                    ),
+                  disabled: session?.role === ROLES.MANAGER_STORE,
                 },
               ],
             },
@@ -131,14 +127,7 @@ const Sidebar = ({
               title: "Проект Лес",
               url: ROUTES_PATH.FOREST,
               icon: TreePine,
-              disabled:
-                session?.role !== ROLES.ADMIN &&
-                session?.role !== ROLES.FOREST &&
-                session?.role !== ROLES.OFFICE_USER &&
-                session?.role !== ROLES.PARTNER &&
-                ![2758, 2564, 2758, 2564, 59, 156, 14, 19, 200].includes(
-                  session?.idUser ?? -1,
-                ),
+              disabled: session?.role === ROLES.MANAGER_STORE,
             },
           ]),
 


### PR DESCRIPTION
- Added ROLES.ANALITIK to allowedRoles for the Unload route.
- Refactored allowedRoles for the Forest route to dynamically include all roles except MANAGER_STORE and FARMER.
- Simplified sidebar access logic for the Forest page to only allow access for users with the MANAGER_STORE role.