### PR TITLE
Refactor download components to remove Excel export button and update…

### DIFF
--- a/src/3_features/farmer/download/ui/download-farmer.tsx
+++ b/src/3_features/farmer/download/ui/download-farmer.tsx
@@ -33,7 +33,6 @@ const DownloadFarmer = ({ rows }: { rows: number }) => {
     setIsOpen(false);
   };
 
-  const isExcelDisabled = true; //rows > 500000;
   const isAllDisabled = rows > 7000000;
   const { session } = useSession();
 
@@ -62,13 +61,6 @@ const DownloadFarmer = ({ rows }: { rows: number }) => {
 
         <DialogFooter className="flex flex-row gap-2 w-full">
           <Button
-            disabled={isExcelDisabled || isAllDisabled}
-            className="w-full bg-green-500"
-            onClick={() => handleDownloadReport("excel")}
-          >
-            Excel
-          </Button>
-          <Button
             disabled={isAllDisabled}
             className="w-full bg-rose-500"
             onClick={() => handleDownloadReport("csv")}
@@ -77,18 +69,20 @@ const DownloadFarmer = ({ rows }: { rows: number }) => {
           </Button>
         </DialogFooter>
 
-        {(isExcelDisabled || isAllDisabled) && (
+        {isAllDisabled && (
           <CardContent className="bg-background p-0 m-0 border-none">
             <CardTitle className="mb-1 flex flex-row items-center gap-1">
-              {isAllDisabled
-                ? "Экспорт данных ограничен"
-                : "Ограничение на экспорт в Excel"}
-              <Sparkles className="size-4 text-primary" />
+              {isAllDisabled && (
+                <>
+                  Экспорт данных ограничен
+                  <Sparkles className="size-4 text-primary" />
+                </>
+              )}
             </CardTitle>
             <CardDescription>
-              {isAllDisabled ? (
+              {isAllDisabled && (
                 <>
-                  В текущей выборке содержится более 7 000 000 строк данных.
+                  В текущей выборке содержится более 1 000 000 строк данных.
                   Экспорт таких объёмов невозможен из-за ограничений системы.
                   <br />
                   <br />
@@ -103,24 +97,6 @@ const DownloadFarmer = ({ rows }: { rows: number }) => {
                       Обратиться в техническую поддержку за альтернативными
                       вариантами экспорта
                     </li>
-                  </ul>
-                </>
-              ) : (
-                <>
-                  В данный момент экспорт в Excel невозможен из-за технических
-                  {/* В текущей выборке содержится более 500 000 строк данных.
-                  Экспорт таких объёмов в Excel невозможен из-за технических
-                  ограничений формата. */}
-                  <br />
-                  <br />
-                  Для работы с большими данными рекомендуем:
-                  <ul className="list-disc pl-5 mt-2 space-y-1">
-                    <li>
-                      Применить дополнительные фильтры для уменьшения выборки
-                    </li>
-                    <li>Использовать группировку данных перед экспортом</li>
-                    <li>Экспортировать данные в формате CSV</li>
-                    <li>Разделить данные на несколько периодов</li>
                   </ul>
                 </>
               )}

--- a/src/3_features/forest/download/ui/download-forest.tsx
+++ b/src/3_features/forest/download/ui/download-forest.tsx
@@ -44,7 +44,6 @@ const DownloadForest = ({ rows, tab }: { rows: number; tab: string }) => {
     setIsOpen(false);
   };
 
-  const isExcelDisabled = true; //rows > 500000;
   const isAllDisabled = rows > 7000000;
   const { session } = useSession();
 
@@ -73,13 +72,6 @@ const DownloadForest = ({ rows, tab }: { rows: number; tab: string }) => {
 
         <DialogFooter className="flex flex-row gap-2 w-full">
           <Button
-            disabled={isExcelDisabled || isAllDisabled}
-            className="w-full bg-green-500"
-            onClick={() => handleDownloadForest("excel")}
-          >
-            Excel
-          </Button>
-          <Button
             disabled={isAllDisabled}
             className="w-full bg-rose-500"
             onClick={() => handleDownloadForest("csv")}
@@ -88,18 +80,20 @@ const DownloadForest = ({ rows, tab }: { rows: number; tab: string }) => {
           </Button>
         </DialogFooter>
 
-        {(isExcelDisabled || isAllDisabled) && (
+        {isAllDisabled && (
           <CardContent className="bg-background p-0 m-0 border-none">
             <CardTitle className="mb-1 flex flex-row items-center gap-1">
-              {isAllDisabled
-                ? "Экспорт данных ограничен"
-                : "Ограничение на экспорт в Excel"}
-              <Sparkles className="size-4 text-primary" />
+              {isAllDisabled && (
+                <>
+                  Экспорт данных ограничен
+                  <Sparkles className="size-4 text-primary" />
+                </>
+              )}
             </CardTitle>
             <CardDescription>
-              {isAllDisabled ? (
+              {isAllDisabled && (
                 <>
-                  В текущей выборке содержится более 7 000 000 строк данных.
+                  В текущей выборке содержится более 1 000 000 строк данных.
                   Экспорт таких объёмов невозможен из-за ограничений системы.
                   <br />
                   <br />
@@ -114,24 +108,6 @@ const DownloadForest = ({ rows, tab }: { rows: number; tab: string }) => {
                       Обратиться в техническую поддержку за альтернативными
                       вариантами экспорта
                     </li>
-                  </ul>
-                </>
-              ) : (
-                <>
-                  В данный момент экспорт в Excel невозможен из-за технических
-                  {/* В текущей выборке содержится более 500 000 строк данных.
-                  Экспорт таких объёмов в Excel невозможен из-за технических
-                  ограничений формата. */}
-                  <br />
-                  <br />
-                  Для работы с большими данными рекомендуем:
-                  <ul className="list-disc pl-5 mt-2 space-y-1">
-                    <li>
-                      Применить дополнительные фильтры для уменьшения выборки
-                    </li>
-                    <li>Использовать группировку данных перед экспортом</li>
-                    <li>Экспортировать данные в формате CSV</li>
-                    <li>Разделить данные на несколько периодов</li>
                   </ul>
                 </>
               )}

--- a/src/3_features/reports/download/ui/download-report.tsx
+++ b/src/3_features/reports/download/ui/download-report.tsx
@@ -33,7 +33,6 @@ const DownloadReport = ({ rows }: { rows: number }) => {
     setIsOpen(false);
   };
 
-  const isExcelDisabled = true; //rows > 500000;
   const isAllDisabled = rows > 1000000;
   const { session } = useSession();
 
@@ -62,13 +61,6 @@ const DownloadReport = ({ rows }: { rows: number }) => {
 
         <DialogFooter className="flex flex-row gap-2 w-full">
           <Button
-            disabled={isExcelDisabled || isAllDisabled}
-            className="w-full bg-green-500"
-            onClick={() => handleDownloadReport("excel")}
-          >
-            Excel
-          </Button>
-          <Button
             disabled={isAllDisabled}
             className="w-full bg-rose-500"
             onClick={() => handleDownloadReport("csv")}
@@ -77,16 +69,18 @@ const DownloadReport = ({ rows }: { rows: number }) => {
           </Button>
         </DialogFooter>
 
-        {(isExcelDisabled || isAllDisabled) && (
+        {isAllDisabled && (
           <CardContent className="bg-background p-0 m-0 border-none">
             <CardTitle className="mb-1 flex flex-row items-center gap-1">
-              {isAllDisabled
-                ? "Экспорт данных ограничен"
-                : "Ограничение на экспорт в Excel"}
-              <Sparkles className="size-4 text-primary" />
+              {isAllDisabled && (
+                <>
+                  Экспорт данных ограничен
+                  <Sparkles className="size-4 text-primary" />
+                </>
+              )}
             </CardTitle>
             <CardDescription>
-              {isAllDisabled ? (
+              {isAllDisabled && (
                 <>
                   В текущей выборке содержится более 1 000 000 строк данных.
                   Экспорт таких объёмов невозможен из-за ограничений системы.
@@ -103,24 +97,6 @@ const DownloadReport = ({ rows }: { rows: number }) => {
                       Обратиться в техническую поддержку за альтернативными
                       вариантами экспорта
                     </li>
-                  </ul>
-                </>
-              ) : (
-                <>
-                  В данный момент экспорт в Excel невозможен из-за технических
-                  {/* В текущей выборке содержится более 500 000 строк данных.
-                  Экспорт таких объёмов в Excel невозможен из-за технических
-                  ограничений формата. */}
-                  <br />
-                  <br />
-                  Для работы с большими данными рекомендуем:
-                  <ul className="list-disc pl-5 mt-2 space-y-1">
-                    <li>
-                      Применить дополнительные фильтры для уменьшения выборки
-                    </li>
-                    <li>Использовать группировку данных перед экспортом</li>
-                    <li>Экспортировать данные в формате CSV</li>
-                    <li>Разделить данные на несколько периодов</li>
                   </ul>
                 </>
               )}

--- a/src/3_features/write-off/download/ui/download-write-off.tsx
+++ b/src/3_features/write-off/download/ui/download-write-off.tsx
@@ -34,7 +34,6 @@ const DownloadWriteOff = ({ rows, tab }: { rows: number; tab: string }) => {
     setIsOpen(false);
   };
 
-  const isExcelDisabled = true; //rows > 500000;
   const isAllDisabled = rows > 7000000;
   const { session } = useSession();
 
@@ -63,13 +62,6 @@ const DownloadWriteOff = ({ rows, tab }: { rows: number; tab: string }) => {
 
         <DialogFooter className="flex flex-row gap-2 w-full">
           <Button
-            disabled={isExcelDisabled || isAllDisabled}
-            className="w-full bg-green-500"
-            //onClick={() => handleDownloadWriteOff("excel")}
-          >
-            Excel
-          </Button>
-          <Button
             disabled={isAllDisabled}
             className="w-full bg-rose-500"
             onClick={() => handleDownloadWriteOff()}
@@ -78,18 +70,20 @@ const DownloadWriteOff = ({ rows, tab }: { rows: number; tab: string }) => {
           </Button>
         </DialogFooter>
 
-        {(isExcelDisabled || isAllDisabled) && (
+        {isAllDisabled && (
           <CardContent className="bg-background p-0 m-0 border-none">
             <CardTitle className="mb-1 flex flex-row items-center gap-1">
-              {isAllDisabled
-                ? "Экспорт данных ограничен"
-                : "Ограничение на экспорт в Excel"}
-              <Sparkles className="size-4 text-primary" />
+              {isAllDisabled && (
+                <>
+                  Экспорт данных ограничен
+                  <Sparkles className="size-4 text-primary" />
+                </>
+              )}
             </CardTitle>
             <CardDescription>
-              {isAllDisabled ? (
+              {isAllDisabled && (
                 <>
-                  В текущей выборке содержится более 7 000 000 строк данных.
+                  В текущей выборке содержится более 1 000 000 строк данных.
                   Экспорт таких объёмов невозможен из-за ограничений системы.
                   <br />
                   <br />
@@ -104,24 +98,6 @@ const DownloadWriteOff = ({ rows, tab }: { rows: number; tab: string }) => {
                       Обратиться в техническую поддержку за альтернативными
                       вариантами экспорта
                     </li>
-                  </ul>
-                </>
-              ) : (
-                <>
-                  В данный момент экспорт в Excel невозможен из-за технических
-                  {/* В текущей выборке содержится более 500 000 строк данных.
-                  Экспорт таких объёмов в Excel невозможен из-за технических
-                  ограничений формата. */}
-                  <br />
-                  <br />
-                  Для работы с большими данными рекомендуем:
-                  <ul className="list-disc pl-5 mt-2 space-y-1">
-                    <li>
-                      Применить дополнительные фильтры для уменьшения выборки
-                    </li>
-                    <li>Использовать группировку данных перед экспортом</li>
-                    <li>Экспортировать данные в формате CSV</li>
-                    <li>Разделить данные на несколько периодов</li>
                   </ul>
                 </>
               )}


### PR DESCRIPTION
… data export limitations

- Removed the Excel export button from DownloadFarmer, DownloadForest, DownloadReport, and DownloadWriteOff components.
- Updated the export limitation messages to reflect a new threshold of 1,000,000 rows for data export.
- Simplified conditional rendering for export restrictions in the UI.