### PR TITLE
Add user-specific access to Admin Notifications in routing and sidebar

### DIFF
--- a/src/0_app/router/routes.tsx
+++ b/src/0_app/router/routes.tsx
@@ -153,6 +153,7 @@ export const ROUTES: RouteConfig[] = [
     path: ROUTES_PATH.ADMIN_NOTIFICATIONS,
     variant: "private",
     allowedRoles: [ROLES.ADMIN],
+    allowedUsers: [156],
     element: <AdminNotifications />,
     layout: Sidebar,
   },

--- a/src/2_widgets/sidebar/ui/sidebar.tsx
+++ b/src/2_widgets/sidebar/ui/sidebar.tsx
@@ -252,7 +252,9 @@ const Sidebar = ({
                 {
                   title: "Уведомления",
                   url: ROUTES_PATH.ADMIN_NOTIFICATIONS,
-                  disabled: session?.role !== ROLES.ADMIN,
+                  disabled:
+                    session?.role !== ROLES.ADMIN &&
+                    ![156].includes(session?.idUser ?? -1),
                 },
                 {
                   title: "Роли голосования",
@@ -272,10 +274,12 @@ const Sidebar = ({
                 ![59, 156].includes(session?.idUser ?? -1),
             },
             {
-              title: "Уведомления",
+              title: "Уведомления (админ)",
               url: ROUTES_PATH.ADMIN_NOTIFICATIONS,
               icon: BellPlus,
-              disabled: session?.role !== ROLES.ADMIN,
+              disabled:
+                session?.role !== ROLES.ADMIN &&
+                ![156].includes(session?.idUser ?? -1),
             },
             {
               title: "Роли голосования",


### PR DESCRIPTION
- Added user ID 156 to the allowedUsers for the Admin Notifications route.
- Updated sidebar to enable the Admin Notifications link for user ID 156, in addition to the ADMIN role.